### PR TITLE
feat: Implement canvas caching for performance improvement

### DIFF
--- a/gui/page.py
+++ b/gui/page.py
@@ -144,6 +144,7 @@ class Page(QWidget):
                 self.drawing_canvas.updateGeometry() # Boyut ipuçlarının değiştiğini bildir
             if hasattr(self.drawing_canvas, 'adjustSize'):
                  self.drawing_canvas.adjustSize() # Canvas'ı yeni sizeHint'e göre ayarla
+            self.drawing_canvas._cache_dirty = True
             self.drawing_canvas.update() # Son olarak yeniden çizim yap
             
     def set_pan(self, pan_offset: QPointF):
@@ -153,6 +154,7 @@ class Page(QWidget):
              self.pan_offset = pan_offset
              logging.debug(f"Sayfa {self.page_number} pan ofseti: ({self.pan_offset.x():.1f}, {self.pan_offset.y():.1f})")
              self.view_changed.emit()
+             self.drawing_canvas._cache_dirty = True
              self.drawing_canvas.update()
              
     def reset_view(self):
@@ -173,6 +175,7 @@ class Page(QWidget):
                 self.drawing_canvas.updateGeometry()
             if hasattr(self.drawing_canvas, 'adjustSize'):
                 self.drawing_canvas.adjustSize()
+            self.drawing_canvas._cache_dirty = True
             self.drawing_canvas.update()
 
     # --- YENİ: Pixmap Yükleme Metodu --- #


### PR DESCRIPTION
I've implemented an offscreen caching mechanism for the DrawingCanvas to improve performance, especially when you're working with a large number of items or actively drawing.

Here are the key changes:
- I introduced an internal cache and a flag to track if it needs updating within the `DrawingCanvas`.
- The drawing process now renders static items (like the background, lines, shapes, B-Splines, and the grid) to this cache when it's marked for an update. Dynamic elements (such as the current drawing stroke or selection handles) are then drawn on top of this cached image.
- I've set up the cache to be invalidated (meaning it will be redrawn) when:
    - Drawing commands (like adding, modifying, or deleting items) are executed or undone.
    - You change the zoom or pan levels.
    - Background templates or page backgrounds are updated.
    - Visual properties like grid settings or fill status are changed.
- I've also optimized B-Spline rendering by caching their calculated points, which reduces recalculations when the main cache is rebuilt.

This should lead to a smoother experience for you and reduced CPU usage during complex drawing operations.