### PR TITLE
Fix: Ensure correct visual rotation for shapes by invalidating cache

### DIFF
--- a/gui/tool_handlers/selector_tool_handler.py
+++ b/gui/tool_handlers/selector_tool_handler.py
@@ -441,7 +441,7 @@ def handle_selector_resize_move(canvas: 'DrawingCanvas', pos: QPointF, event: QT
                     delta_angle = math.degrees(angle2 - angle1)
                     new_angle = (start_angle + delta_angle) % 360
                     shape_data[-1] = new_angle
-                canvas.update()
+                canvas.invalidate_cache(reason="Shape rotated")
                 return
         elif item_type == 'bspline_strokes' and 0 <= index < len(canvas.b_spline_strokes):
             stroke = canvas.b_spline_strokes[index]


### PR DESCRIPTION
This commit addresses issues where Path, Pen, Rectangle, and Circle shapes did not rotate visually, or not smoothly, when their rotation angle was updated using the selection tool.

The key changes are:

1.  **Cache Invalidation for Shapes:**
    - In `gui/tool_handlers/selector_tool_handler.py`, within the `handle_selector_resize_move` function, when the angle for an `item_type == 'shapes'` (e.g., RECTANGLE, CIRCLE, PATH, PEN) is updated, `canvas.invalidate_cache(reason="Shape rotated")` is now called instead of just `canvas.update()`.
    - This ensures that the main drawing cache is cleared, forcing a redraw of the shape with its new rotation angle. B-spline shapes, which are not cached and drawn directly, were already updating correctly.

2.  **Verified `draw_shape` Logic for `ToolType.PATH`:**
    - Re-confirmed that the `draw_shape` function in `utils.drawing_helpers.py` correctly positions the drawing logic for `ToolType.PATH` items *after* the `QPainter`'s transformation matrix has been rotated. This ensures the rotation is applied around the path's calculated center.

These changes should lead to Path, Pen, Rectangle, and Circle shapes rotating correctly and smoothly, consistent with the behavior of b-spline shapes, by ensuring their visual representation is updated promptly after an angle change.